### PR TITLE
Adding envy to our pipenv dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -25,6 +25,7 @@ wrapt = "==1.11.1"
 websocket_client = "==0.56.0"
 dockerpty = {editable = true,git = "https://github.com/deanrock/dockerpty",ref = "new-docker-library"}
 pyyaml = "*"
+envy = {editable = true,path = "."}
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1378e173bc649083fff84c0737118c93cb31ad51a861449c642e94aa5e6d86dc"
+            "sha256": "eea7395501c1f5741577cf93cea5b6706ce735443513fa2e5d6a51b3ceb65c87"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -57,6 +57,10 @@
             "editable": true,
             "git": "https://github.com/deanrock/dockerpty",
             "ref": "73cc6f947a9501717b42158a9e839bf96bedeb69"
+        },
+        "envy": {
+            "editable": true,
+            "path": "."
         },
         "idna": {
             "hashes": [


### PR DESCRIPTION
I was getting super annoyed with having to reinstall envy every time I made a code change that I wanted to test. This adds envy as a dependency in editable mode, which links straight to our code. Makes everything so much easier.