### PR TITLE
Change envy state to be one json object rather than multiple files

### DIFF
--- a/envy/lib/state/envy_state.py
+++ b/envy/lib/state/envy_state.py
@@ -42,9 +42,6 @@ class EnvyState:
     def update_environment_hash(self):
         self.set_environment_hash(ENVY_CONFIG.get_environment_hash())
 
-    def __get_environment_file(self):
-        return "{}/environment.md5".format(self.directory)
-
     def get_container_id(self):
         return self.__get(["container", "dockerid"])
 


### PR DESCRIPTION
This change removes any reading from and writing to individual files, and replaces reading or writing with reading from or writing to a state dictionary. This state dictionary is persisted in a single json file, `.envy/state.json`