### PR TITLE
Fixing single string issue with script setup step

### DIFF
--- a/envy/lib/setup_step/script_setup_step.py
+++ b/envy/lib/setup_step/script_setup_step.py
@@ -11,5 +11,8 @@ class ScriptSetupStep(AssignableTriggerStep):
     def run(self):
         super().run()
 
-        for step in self._scripts:
-            self._container.exec(step)
+        if isinstance(self._scripts, str):
+            self._container.exec(self._scripts)
+        else:
+            for step in self._scripts:
+                self._container.exec(step)


### PR DESCRIPTION
For the `run` key of our `script` setup steps, we're allowing either an array of scripts, or a single string script. However, we didn't check the type of the payload when executing it, so we would iterate over each character of the string in the single case instead of executing it properly. Fixed that.