### PR TITLE
Supporting custom project mount path

### DIFF
--- a/envy/lib/config/envy_config.py
+++ b/envy/lib/config/envy_config.py
@@ -24,15 +24,23 @@ class EnvyConfig:
         self.data = validate_schema(raw_data)
 
     def get_image_hash(self) -> str:
+        relevant_dict = {
+            "base": self.data["environment"]["base"],
+            "system-packages": self.data["environment"]["system-packages"],
+        }
+
         return hashlib.md5(
-            json.dumps(self.data["environment"]["base"], sort_keys=True).encode("utf-8")
+            json.dumps(relevant_dict, sort_keys=True).encode("utf-8")
         ).hexdigest()
 
     def get_container_hash(self) -> str:
+        relevant_dict = {
+            "steup-steps": self.data["environment"]["setup-steps"],
+            "project-dir": self.data["environment"]["project-dir"],
+        }
+
         return hashlib.md5(
-            json.dumps(self.data["environment"]["setup-steps"], sort_keys=True).encode(
-                "utf-8"
-            )
+            json.dumps(relevant_dict, sort_keys=True).encode("utf-8")
         ).hexdigest()
 
     def get_base_image(self) -> str:
@@ -48,6 +56,14 @@ class EnvyConfig:
 
     def __guess_package_manager(self) -> str:
         return "apt"
+
+    def get_project_mount_path(self) -> str:
+        path = self.data["environment"]["project-dir"]
+
+        if path[-1] == "/":
+            return path[: len(path) - 1]
+
+        return path
 
     def get_system_packages(self) -> [{}]:
         return self.data["environment"]["system-packages"]

--- a/envy/lib/config/schema.py
+++ b/envy/lib/config/schema.py
@@ -4,8 +4,11 @@ from schema import Schema, SchemaError, Optional, And, Or, Use
 
 _DEFAULT_ENVIRONMENT_BASE = {"image": "ubuntu:18.04", "package-manager": "apt"}
 
+_DEFAULT_PROJECT_DIR = "/project"
+
 _DEFAULT_ENVIRONMENT = {
     "base": _DEFAULT_ENVIRONMENT_BASE,
+    "project-dir": _DEFAULT_PROJECT_DIR,
     "system-packages": [],
     "setup-steps": [],
 }
@@ -15,6 +18,20 @@ _STEP_TYPES = ["script", "remote"]
 _SIMPLE_TRIGGERS = ["always"]
 
 _DEFAULT_TRIGGERS = {"system-packages": [], "files": [], "steps": []}
+
+
+def __validate_project_dir(project_dir: str) -> bool:
+    if not project_dir:
+        print("Project directory cannot be empty")
+        return False
+    if project_dir[0] != "/":
+        print("Project directory must have an absolute root path")
+        return False
+    if len(project_dir) == 1:
+        print("Root is not a valid project directory")
+        return False
+
+    return True
 
 
 def __validate_setup_step(step: {}) -> bool:
@@ -83,6 +100,9 @@ _SCHEMA = Schema(
                     "image": str,
                     Optional("package-manager"): str,
                 },
+                Optional("project-dir", default=_DEFAULT_PROJECT_DIR): And(
+                    str, __validate_project_dir
+                ),
                 Optional("system-packages", default=[]): [
                     {"recipe": str, Optional("version"): Or(str, int, float)}
                 ],


### PR DESCRIPTION
closes #29 

Supporting a custom project mount path. Will default to `/project` as before, so most users need not be aware that this feature exists. Some will find it very useful though, especially those setting up golang projects without the new go modules.

Doing some basic validation to make sure the path is absolute and will work. Mount will create the subdirectories for us if they don't already exist.