### PR TITLE
Supporting custom base images (still forcing apt package manager)

### DIFF
--- a/.envyfile
+++ b/.envyfile
@@ -1,21 +1,15 @@
 environment:
+  base:
+    image: python:3.7.3-slim-stretch
   system-packages:
     - recipe: docker
       version: 1.5-1build1
     - recipe: git
-    - recipe: python3.7
-    - recipe: python3-pip
   setup-steps:
     - name: pipenv
       type: script
       run:
-        - "rm /usr/bin/python3"
-        - "ln -s /usr/bin/python3.7 /usr/bin/python3"
         - "pip3 install pipenv"
-      triggers:
-        system-packages:
-          - python3.7
-          - python3-pip
     - name: python-deps
       type: script
       run:
@@ -31,8 +25,8 @@ actions:
     script: 'pipenv run black . ; pipenv run pylint envy'
     help: 'lint the project'
   - name: pylint
-    script: 'cd envy ; pylint envy'
+    script: 'pipenv run pylint envy'
     help: 'run pylint alone'
   - name: black
-    script: 'black .'
+    script: 'pipenv run black .'
     help: 'run black alone'

--- a/envy/lib/docker_manager/image_creators/apt_image_creator.py
+++ b/envy/lib/docker_manager/image_creators/apt_image_creator.py
@@ -2,9 +2,6 @@ from .image_creator import ImageCreator
 
 
 class AptImageCreator(ImageCreator):
-    def base_image(self):
-        return "ubuntu:18.04"
-
     def get_package_string(self, packages):
         # TODO: validation here to ensure shell safety
         apt_string = " ".join([package["recipe"] for package in packages])

--- a/envy/lib/docker_manager/image_creators/image_creator.py
+++ b/envy/lib/docker_manager/image_creators/image_creator.py
@@ -71,13 +71,9 @@ class ImageCreator(ABC):
             Returns:
                 string: the string representation of the Dockerfile
         """
-        d_file = "FROM " + self.base_image() + "\n"
-        d_file += "RUN " + self.get_package_string(packages) + "\n"
+        d_file = f"FROM {ENVY_CONFIG.get_base_image()}\n"
+        d_file += f"RUN {self.get_package_string(packages)}\n"
         return d_file
-
-    @abstractmethod
-    def base_image(self):
-        pass
 
     @abstractmethod
     def get_package_string(self, packages):


### PR DESCRIPTION
closes #30 

Supporting custom base images. We already have the proper .envyfile schema and defaults in place, so this PR just switches over our `ImageCreator` to honour the base image specified in the config, rather than defaulting to ubuntu.

We're still forcing apt, since thats the only package manager we support for now. This will break if the provided base image doesn't have apt.

I also updated our own envyfile to use the `python:3.7-slim-stretch` base image, which is a debian image with python3.7 and pip3 preinstalled. This lets me cut out some of our extra setup steps 🎉