### PR TITLE
Update packaging so that envy can be installed from pip

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,6 @@ pylint = "==2.3.1"
 black = "*"
 
 [packages]
-dockerpty = {editable = true,git = "https://github.com/deanrock/dockerpty",ref = "new-docker-library"}
 envy = {editable = true,path = "."}
 
 [pipenv]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b3fe6bc3498d8465fb45a3592398f889d1a07a5099fd0e9e019a64a8b7fc240e"
+            "sha256": "02b6d809d3563ccecbd2946f3d74b24e613a9f9b9d8735d47811fec6bb954653"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -43,9 +43,10 @@
             "version": "==4.0.2"
         },
         "dockerpty": {
-            "editable": true,
-            "git": "https://github.com/deanrock/dockerpty",
-            "ref": "73cc6f947a9501717b42158a9e839bf96bedeb69"
+            "hashes": [
+                "sha256:69a9d69d573a0daa31bcd1c0774eeed5c15c295fe719c61aca550ed1393156ce"
+            ],
+            "version": "==0.4.1"
         },
         "envy": {
             "editable": true,

--- a/setup.py
+++ b/setup.py
@@ -15,16 +15,16 @@ from setuptools import find_packages, setup, Command
 NAME = "envy-project"
 DESCRIPTION = "Create and manage developments environment."
 URL = "https://github.com/envy-project/envy"
-EMAIL = "alex@magmastone.com"
+EMAIL = "alex@magmastone.net"
 AUTHOR = "Envy Team"
 REQUIRES_PYTHON = ">=3.7.0"
-VERSION = "0.1.0"
+VERSION = "0.1.2"
 
 # What packages are required for this module to be executed?
 REQUIRED = [
     "docker",
     "schema",
-    "dockerpty @ git+https://github.com/deanrock/dockerpty@new-docker-library#egg=dockerpty-git-1.0.0",
+    "envy-project-dockerpty-republish",
     "pyyaml",
     "requests",
 ]


### PR DESCRIPTION
Once I release a new Pip version, this fixes #33 .


Re-published the fixed dockerpty under envy-project.