### PR TITLE
Pass Apt options so that it's actually likely to succeed

### DIFF
--- a/envy/lib/setup_step/apt_package_manager_step.py
+++ b/envy/lib/setup_step/apt_package_manager_step.py
@@ -32,7 +32,7 @@ class AptPackageManagerStep(PackageManagerStep):
             [versioned_package for versioned_package in versioned_packages]
         )
         self._container.exec(
-            "apt-get update && apt-get install -y {} && rm -rf /var/lib/apt/lists/*".format(
+            'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y {} && rm -rf /var/lib/apt/lists/*'.format(
                 apt_string
             )
         )


### PR DESCRIPTION
Without this, it'll get hung up by several packages, **especially** with our partial-upgrades strategy.

note that this isn't *everything* you need. We'd also need to pass options to allow downgrading packages (again, only applies because of the partial-upgrades), but that's actually a *really* dangerous one to pass in because it applies along large dependency chains.