### PR TITLE
Default to run things with the same UID/GID as the user invoking ENVy

### DIFF
--- a/.envyfile
+++ b/.envyfile
@@ -8,6 +8,7 @@ environment:
   setup-steps:
     - name: pipenv
       type: script
+      as_user: false
       run:
         - "pip3 install pipenv"
     - name: python-deps

--- a/envy/envy.py
+++ b/envy/envy.py
@@ -57,7 +57,7 @@ def shell_command(_args: argparse.Namespace, _unknown_args: [str]):
         print(STATUS_MSG_CONTAINER_STOPPED)
         return
 
-    container.exec("/bin/bash")
+    container.exec("/bin/bash", True)
 
 
 def down_command(_args: argparse.Namespace, _unknown_args: [str]):
@@ -128,7 +128,7 @@ def run_script(_args: argparse.Namespace, unknown_args: [str], script: str):
         print(STATUS_MSG_CONTAINER_STOPPED)
     else:
         command = "{} {}".format(script, " ".join(unknown_args))
-        container.exec(command)
+        container.exec(command, True)
 
 
 def build_custom_command_parser(subparsers, name: str, info: {}):

--- a/envy/lib/config/schema.py
+++ b/envy/lib/config/schema.py
@@ -123,6 +123,7 @@ _SCHEMA = Schema(
                                     Optional("steps", default=[]): [str],
                                 },
                             ),
+                            Optional("as_user", default=True): bool,
                             Or("run", "url", "path", only_one=True): Or([str], str),
                         },
                         __validate_setup_step,

--- a/envy/lib/docker_manager/container_manager.py
+++ b/envy/lib/docker_manager/container_manager.py
@@ -90,9 +90,6 @@ class ContainerManager:
 
         return bool("running" in container.status)
 
-    def exec(self, command: str, ):
-        """ Executes the command in the containers
-
     def exec(self, command: str, as_user: bool = False, relpath: str = None):
         """ Executes the command in the container
 

--- a/envy/lib/setup_step/builder.py
+++ b/envy/lib/setup_step/builder.py
@@ -23,6 +23,9 @@ class Builder:
         # Create system packages step
         self.__create_system_packages_step()
 
+        # Create initial-setup step
+        self.__create_initial_setup_steps()
+
         # Create steps
         self.__create_steps()
 
@@ -38,12 +41,19 @@ class Builder:
         )
         self.steps[self.system_package_step.name] = self.system_package_step
 
+    def __create_initial_setup_steps(self):
+        # Hack to get some things to play nice with /root being home folder.
+        chmod_step = ScriptSetupStep(
+            "ENVY_chmod_root", self.container, "chmod a+wrx /root", False
+        )
+        self.steps[chmod_step.name] = chmod_step
+
     def __create_steps(self):
         for m in ENVY_CONFIG.get_setup_steps():
             # Create step
             name = m["name"]
             if m["type"] == "script":
-                step = ScriptSetupStep(name, self.container, m["run"])
+                step = ScriptSetupStep(name, self.container, m["run"], m["as_user"])
             elif m["type"] == "remote":
                 step = RemoteSetupStep(name, self.container, m["url"])
 

--- a/envy/lib/setup_step/script_setup_step.py
+++ b/envy/lib/setup_step/script_setup_step.py
@@ -4,15 +4,22 @@ from .assignable_trigger_step import AssignableTriggerStep
 
 
 class ScriptSetupStep(AssignableTriggerStep):
-    def __init__(self, name: str, container: ContainerManager, scripts: [str]):
+    def __init__(
+        self,
+        name: str,
+        container: ContainerManager,
+        scripts: [str],
+        as_user: bool = True,
+    ):
         super().__init__(name, container)
         self._scripts = scripts
+        self._as_user = as_user
 
     def run(self):
         super().run()
 
         if isinstance(self._scripts, str):
-            self._container.exec(self._scripts)
+            self._container.exec(self._scripts, self._as_user)
         else:
             for step in self._scripts:
-                self._container.exec(step)
+                self._container.exec(step, self._as_user)


### PR DESCRIPTION
This took some figuring.

I've added the concept of ENVY-defined pre-setup steps. Those will (hopefully!) be cross-platform enough to work everywhere.

The chmod is a hack. I'm not a fan, but it's better than most of the other things I tried, and doesn't involve an extra binary to download and inject into containers (which I can imagine will bother some users). It's also pretty cross-platform - even Alpine images will work.

An extra "as_user" config option is added to script steps to allow forcing to run as root - for things like pip that expect to run as root. Will update docs. Omer's work on error code is _required_ for this to make it into a release - otherwise steps will fail due to permissions and you'll have no way to know, just a horribly broken image.