### PR TITLE
Recovering exit code from docker exec

### DIFF
--- a/envy/lib/docker_manager/container_manager.py
+++ b/envy/lib/docker_manager/container_manager.py
@@ -121,9 +121,11 @@ class ContainerManager:
                 command.replace("'", "'\\''"),
             )
 
-        dockerpty.exec_command(
+        exit_code = dockerpty.exec_command(
             self.docker_client, self.container_id, command_inside_project
         )
+
+        return exit_code
 
     def ensure_running(self):
         """ Ensures that the container is running


### PR DESCRIPTION
This is a step towards addressing #46.
The other half of https://github.com/envy-project/dockerpty/pull/1.

This PR just recovers the `exit_code` which is now returned by our fork of dockerpty. We can use this in the future to detect that a setup step failed.