### PR TITLE
Add error code reporting

### DIFF
--- a/envy/envy.py
+++ b/envy/envy.py
@@ -69,7 +69,9 @@ def shell_command(_args: argparse.Namespace, _unknown_args: [str]):
             print(STATUS_MSG_CONTAINER_STOPPED)
             return
 
-        container.exec("/bin/bash", as_user=True, relpath=str(ENVY_CURRENT_RELATIVE_PATH))
+        container.exec(
+            "/bin/bash", as_user=True, relpath=str(ENVY_CURRENT_RELATIVE_PATH)
+        )
     except ContainerError as err:
         print("Shell exited with error code {}".format(err.code))
 

--- a/envy/lib/docker_manager/__init__.py
+++ b/envy/lib/docker_manager/__init__.py
@@ -1,3 +1,3 @@
 from .docker_manager import DockerManager
 from .compose_manager import ComposeManager
-from .container_manager import ContainerManager
+from .container_manager import ContainerError, ContainerManager

--- a/envy/lib/docker_manager/container_manager.py
+++ b/envy/lib/docker_manager/container_manager.py
@@ -16,6 +16,7 @@ class ContainerNotFound(Exception):
 class ContainerNotRunning(Exception):
     pass
 
+
 class ContainerError(Exception):
     def __init__(self, code):
         super(ContainerError, self).__init__(code)

--- a/envy/lib/docker_manager/container_manager.py
+++ b/envy/lib/docker_manager/container_manager.py
@@ -16,6 +16,11 @@ class ContainerNotFound(Exception):
 class ContainerNotRunning(Exception):
     pass
 
+class ContainerError(Exception):
+    def __init__(self, code):
+        super(ContainerError, self).__init__(code)
+        self.code = code
+
 
 class ContainerManager:
     ### Static Container Creation ###
@@ -125,7 +130,8 @@ class ContainerManager:
             self.docker_client, self.container_id, command_inside_project
         )
 
-        return exit_code
+        if exit_code != 0:
+            raise ContainerError(exit_code)
 
     def ensure_running(self):
         """ Ensures that the container is running

--- a/envy/lib/io/step_printer.py
+++ b/envy/lib/io/step_printer.py
@@ -1,6 +1,7 @@
 ENDC = "\033[0m"
-YELLOW = "\033[33m"
+RED = "\033[31m"
 GREEN = "\033[32m"
+YELLOW = "\033[33m"
 
 
 class StepPrinter:
@@ -22,4 +23,11 @@ class StepPrinter:
         """
 
         print("{}{} {}{}".format(GREEN, self.current_step, u"\u2713", ENDC))
+        self.current_step = ""
+
+    def error(self, code):
+        """ Print the most recently started step with an error code
+        """
+
+        print("{}{} exited with error code {} {}{}".format(RED, self.current_step, code, u"\u2717", ENDC))
         self.current_step = ""

--- a/envy/lib/io/step_printer.py
+++ b/envy/lib/io/step_printer.py
@@ -29,5 +29,9 @@ class StepPrinter:
         """ Print the most recently started step with an error code
         """
 
-        print("{}{} exited with error code {} {}{}".format(RED, self.current_step, code, u"\u2717", ENDC))
+        print(
+            "{}{} exited with error code {} {}{}".format(
+                RED, self.current_step, code, u"\u2717", ENDC
+            )
+        )
         self.current_step = ""


### PR DESCRIPTION
Adds error code reporting to all envy commands

If this command was using a StepPrinter, we now print out the name of the ended step with the error code. Otherwise, we just print a message saying "{commandname} exited with error code {n}".