### PR TITLE
Allow a selectable docker network instead of host

### DIFF
--- a/envy/lib/config/envy_config.py
+++ b/envy/lib/config/envy_config.py
@@ -53,7 +53,7 @@ class EnvyConfig:
         return self.data["actions"]
 
     def get_network_mode(self) -> Optional[str]:
-        return "host" if self.data["network"] else None
+        return None if self.data["network"] else "host"
 
     def get_network(self) -> Optional[str]:
         return self.data.get("network")

--- a/envy/lib/config/envy_config.py
+++ b/envy/lib/config/envy_config.py
@@ -52,5 +52,11 @@ class EnvyConfig:
     def get_actions(self) -> [{}]:
         return self.data["actions"]
 
+    def get_network_mode(self) -> Optional[str]:
+        return "host" if self.data["network"] else None
+
+    def get_network(self) -> Optional[str]:
+        return self.data.get("network")
+
     def get_services_compose_path(self) -> Optional[str]:
         return self.data["services"].get("compose-file")

--- a/envy/lib/config/schema.py
+++ b/envy/lib/config/schema.py
@@ -142,6 +142,7 @@ _SCHEMA = Schema(
             }
         ],
         Optional("services", default={}): {Optional("compose-file"): str},
+        Optional("network", default=None): str,
     }
 )
 

--- a/envy/lib/docker_manager/container_manager.py
+++ b/envy/lib/docker_manager/container_manager.py
@@ -46,7 +46,8 @@ class ContainerManager:
             image_id,
             "tail -f /dev/null",
             name=ContainerManager.__generate_container_name(),
-            network_mode="host",
+            network=ENVY_CONFIG.get_network(),
+            network_mode=ENVY_CONFIG.get_network_mode(),
             mounts=[
                 Mount(
                     ENVY_CONFIG.get_project_mount_path(),

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = "https://github.com/envy-project/envy"
 EMAIL = "alex@magmastone.net"
 AUTHOR = "Envy Team"
 REQUIRES_PYTHON = ">=3.7.0"
-VERSION = "1.1.1"
+VERSION = "1.2.0"
 
 # What packages are required for this module to be executed?
 REQUIRED = [


### PR DESCRIPTION
Sidecars without host networking may not work well with ENVY if they don't expose all the ports they care about. This allows us to write envyfiles that will attached to a docker network to try and support these cases without modifying the `docker-compose.yml`.