### PR TITLE
Create users and groups as part of envy up.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = "https://github.com/envy-project/envy"
 EMAIL = "alex@magmastone.net"
 AUTHOR = "Envy Team"
 REQUIRES_PYTHON = ">=3.7.0"
-VERSION = "1.1.0"
+VERSION = "1.1.1"
 
 # What packages are required for this module to be executed?
 REQUIRED = [


### PR DESCRIPTION
This commit updates /etc/passwd and /etc/group. This should work for the vast, vast majority of docker container bases out there.

This is more correct than our past approach of just ignoring the missing users/groups, and it was causing home-assistant test/lint steps to break.

Update setup.py to bump version. Semver minor bump since this fixes functionality and isn't a breaking change.