### PR TITLE
Supporting X-forwarding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ You can install ENVy in a few different ways:
    - Extract the archive (`tar -xzvf envy-*.tgz`)
    - Install the package (`sudo setup.py install`)
 
+**Special Instructions for Mac OS X**:
+   - Install [Docker for Mac](https://docs.docker.com/docker-for-mac/install/).
+   - If your project uses X-forwarding:
+     1. Install [XQuartz](https://www.xquartz.org/).
+     2. Enable the "Allow connections from network clients" setting under XQuartz's security tab.
+     3. (re)Start XQuartz. XQuartz must be running for X-forwarding to work.
+
 Using ENVy as a contributor
 ---
 

--- a/envy/lib/config/envy_config.py
+++ b/envy/lib/config/envy_config.py
@@ -60,3 +60,6 @@ class EnvyConfig:
 
     def get_services_compose_path(self) -> Optional[str]:
         return self.data["services"].get("compose-file")
+
+    def should_x_forward(self) -> bool:
+        return self.data["environment"]["x-forward"]

--- a/envy/lib/config/schema.py
+++ b/envy/lib/config/schema.py
@@ -6,8 +6,11 @@ _DEFAULT_ENVIRONMENT_BASE = {"image": "ubuntu:18.04", "package-manager": "apt"}
 
 _DEFAULT_PROJECT_DIR = "/project"
 
+_DEFAULT_X_FORWARD = False
+
 _DEFAULT_ENVIRONMENT = {
     "base": _DEFAULT_ENVIRONMENT_BASE,
+    "x-forward": _DEFAULT_X_FORWARD,
     "project-dir": _DEFAULT_PROJECT_DIR,
     "system-packages": [],
     "setup-steps": [],
@@ -100,6 +103,7 @@ _SCHEMA = Schema(
                     "image": str,
                     Optional("package-manager"): str,
                 },
+                Optional("x-forward", default=_DEFAULT_X_FORWARD): bool,
                 Optional("project-dir", default=_DEFAULT_PROJECT_DIR): And(
                     str, __validate_project_dir
                 ),

--- a/envy/lib/docker_manager/container_manager.py
+++ b/envy/lib/docker_manager/container_manager.py
@@ -65,7 +65,6 @@ class ContainerManager:
                 )
 
             mounts += [Mount("/tmp/.X11-unix", "/tmp/.X11-unix", type="bind")]
-            # TODO mac users need to enable the "Allow connections from network clients" setting in xQuartz. document this.
             if platform.system() == "Darwin":
                 environment["DISPLAY"] = "host.docker.internal:0"
             else:

--- a/envy/lib/docker_manager/container_manager.py
+++ b/envy/lib/docker_manager/container_manager.py
@@ -1,7 +1,6 @@
 from hashlib import md5
 import os
 import platform
-import subprocess
 from pathlib import Path
 from docker.types import Mount
 from docker import DockerClient
@@ -55,15 +54,6 @@ class ContainerManager:
         ]
 
         if ENVY_CONFIG.should_x_forward():
-            try:
-                subprocess.run(
-                    ["xhost", "+", "localhost"], check=True, capture_output=True
-                )
-            except subprocess.SubprocessError:
-                print(
-                    "WARNING: failed to allow x-forwarding from localhost, but x-forwarding is enabled. X applications will likely fail."
-                )
-
             mounts += [Mount("/tmp/.X11-unix", "/tmp/.X11-unix", type="bind")]
             if platform.system() == "Darwin":
                 environment["DISPLAY"] = "host.docker.internal:0"

--- a/envy/lib/docker_manager/container_manager.py
+++ b/envy/lib/docker_manager/container_manager.py
@@ -1,5 +1,6 @@
 from hashlib import md5
 import os
+import platform
 import subprocess
 from pathlib import Path
 from docker.types import Mount
@@ -64,9 +65,11 @@ class ContainerManager:
                 )
 
             mounts += [Mount("/tmp/.X11-unix", "/tmp/.X11-unix", type="bind")]
-            # TODO $DISPLAY must be special cased for mac. On Linux it should just be ":0"
             # TODO mac users need to enable the "Allow connections from network clients" setting in xQuartz. document this.
-            environment["DISPLAY"] = "host.docker.internal:0"
+            if platform.system() == "Darwin":
+                environment["DISPLAY"] = "host.docker.internal:0"
+            else:
+                environment["DISPLAY"] = ":0"
 
         container = docker_client.containers.create(
             image_id,


### PR DESCRIPTION
Added a new configuration flag under `environment` to enable x-forwarding for the project.
This should "just work" for a very large number of host machines, including Mac.

Enabling `x-forward` binds `/tmp/.X11-unix` (the X sockets) into the container, and sets the appropriate `$DISPLAY` variable.

This [example project](https://github.com/envy-project/examples/pull/9) demonstrates x-forwarding by running `xeyes` in envy.
I've also updated the [documentation site](https://envy-project.github.io/envyfile-reference.html) with the new config flag.