### PR TITLE
Defaulting docker image tag to :latest

### DIFF
--- a/envy/lib/docker_manager/docker_manager.py
+++ b/envy/lib/docker_manager/docker_manager.py
@@ -64,16 +64,18 @@ class DockerManager:
         if self.get_container():
             raise ContainerExists()
 
+        image = ENVY_CONFIG.get_base_image()
+        if ":" not in image:
+            image += ":latest"
+
         try:
-            self.docker_client.images.get(ENVY_CONFIG.get_base_image())
+            self.docker_client.images.get(image)
         except docker.errors.ImageNotFound:
             print("Pulling base image, this may take a while...")
 
-        self.docker_client.images.pull(ENVY_CONFIG.get_base_image())
+        self.docker_client.images.pull(image)
 
-        container_manager = ContainerManager.create(
-            self.docker_client, ENVY_CONFIG.get_base_image()
-        )
+        container_manager = ContainerManager.create(self.docker_client, image)
 
         ENVY_STATE.set_container_id(container_manager.container_id)
 


### PR DESCRIPTION
`docker pull` defaults to pulling the `:latest` tag if none is supplied, but the python API we use [does not](https://docker-py.readthedocs.io/en/stable/images.html#docker.models.images.ImageCollection.pull). 

Thus, if the envyfile doesn't specify the tag, ENVy will pull every single version of the image. This PR fixes that by defaulting to the `:latest` tag like the docker CLI does.